### PR TITLE
Fix: merge projectItems in root

### DIFF
--- a/src/LigerShark.TemplateBuilder.Tasks/CreateTemplateTask.cs
+++ b/src/LigerShark.TemplateBuilder.Tasks/CreateTemplateTask.cs
@@ -55,8 +55,8 @@ namespace LigerShark.TemplateBuilder.Tasks {
 
         public void RecurseItems(XElement projectItemContainer, string sourcePrefix, string targetPrefix, HashSet<string> takenSourceFileNames, HashSet<string> takenTargetFileNames) {
             foreach (var projectItem in projectItemContainer.Elements(XName.Get("ProjectItem", VsTemplateSchema))) {
-                takenSourceFileNames.Add(string.Format(@"{0}\{1}", sourcePrefix, projectItem.Value.ToLowerInvariant()));
-                takenTargetFileNames.Add(string.Format(@"{0}\{1}", sourcePrefix, projectItem.Attribute(XName.Get("TargetFileName")).Value.ToLowerInvariant()));
+                takenSourceFileNames.Add(Path.Combine(sourcePrefix, projectItem.Value.ToLowerInvariant()));
+                takenTargetFileNames.Add(Path.Combine(sourcePrefix, projectItem.Attribute(XName.Get("TargetFileName")).Value.ToLowerInvariant()));
             }
 
             foreach (var folder in projectItemContainer.Elements(XName.Get("Folder", VsTemplateSchema))) {


### PR DESCRIPTION
If 'sourcePrefix' variable is empty, then added prefix '\' before 'projectItem...'. Because merge was failed
