### PR TITLE
Added bin and obj to the list of folders to skip during robocopy

### DIFF
--- a/tools/ligershark.templates.targets
+++ b/tools/ligershark.templates.targets
@@ -530,7 +530,7 @@ _ls-DestVsTemplateFullPath: [$(_ls-DestVsTemplateFullPath)]" Importance="low"/>
       <Output TaskParameter ="CopiedFiles" ItemName="ls-temp-FilesCopied"/>
     </Copy>
     <ItemGroup>
-      <ls-FoldersToSkip Include="node_modules;bower_components;_Definitions"/>
+      <ls-FoldersToSkip Include="node_modules;bower_components;_Definitions;bin;obj"/>
     </ItemGroup>
     <!-- copy source folder to dest so that the files can be included in the generated vsix -->
     <PropertyGroup>


### PR DESCRIPTION
Every time I open the solution, the bin and obj folders are created even though my project template is not set to build. This causes these folders and their contents to be copied to the VSIX. I have to remember to manually delete these folders before I build my VSIX.

Adding these two folders to the excludes also has the nice side effect that you no longer need to set you project template to not build in the solution configuration.