### PR TITLE
Wizard For Fixing .xproj Artifacts Output File Path

### DIFF
--- a/src/TemplateBuilder/FixArtifactsPathWizard.cs
+++ b/src/TemplateBuilder/FixArtifactsPathWizard.cs
@@ -7,23 +7,84 @@
     using Microsoft.Build.Construction;
     using Microsoft.Build.Evaluation;
     using Microsoft.VisualStudio.TemplateWizard;
+    using TemplateBuilder.Helpers;
 
     public class FixArtifactsPathWizard : IWizard
     {
+        private const string BaseIntermediateOutputPathPropertyName = "BaseIntermediateOutputPath";
+        private const string OutputPathPropertyName = "OutputPath";
+
         #region Public Methods
 
         public void BeforeOpeningFile(global::EnvDTE.ProjectItem projectItem)
         {
         }
-        
+
         public void ProjectFinishedGenerating(global::EnvDTE.Project project)
         {
             var projectFilePath = project.FileName;
             var solutionFilePath = project.DTE.Solution.FileName;
 
-            if (Execute(solutionFilePath, projectFilePath))
+            if (!string.Equals(Path.GetExtension(projectFilePath), ".xproj"))
             {
-                project.Save();
+                return;
+            }
+
+            var projectDirectoryPath = Path.GetDirectoryName(projectFilePath);
+            var solutionDirectoryPath = string.IsNullOrEmpty(solutionFilePath) ? projectDirectoryPath : Path.GetDirectoryName(solutionFilePath);
+
+            var artifactsObjDirectoryPath = Path.Combine(solutionDirectoryPath, @"artifacts\obj\$(MSBuildProjectName)");
+            var artifactsBinDirectoryPath = Path.Combine(solutionDirectoryPath, @"artifacts\bin\$(MSBuildProjectName)");
+
+            var relativeObjPackagesDirectoryPath = PathHelper.GetRelativePath(
+                projectDirectoryPath,
+                artifactsObjDirectoryPath);
+            var relativeBinPackagesDirectoryPath = PathHelper.GetRelativePath(
+                projectDirectoryPath,
+                artifactsBinDirectoryPath);
+
+            //<PropertyGroup Label="Globals">
+            //  <ProjectGuid>6e0ef33d-3c19-4ea2-8ca9-c7bf19bdd947</ProjectGuid>
+            //  <RootNamespace>MvcBoilerplate</RootNamespace>
+            //  <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+            //  <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+            //</PropertyGroup>
+
+            bool hasChanged = false;
+            Project buildProject = new Project(projectFilePath);
+
+            var baseIntermediateOutputPathElement = buildProject
+                .Xml
+                .PropertyGroups
+                .FirstOrDefault(x => string.Equals(x.Label, "Globals"))?
+                .Children
+                .OfType<ProjectPropertyElement>()
+                .FirstOrDefault(x => string.Equals(x.Name, BaseIntermediateOutputPathPropertyName));
+            if (baseIntermediateOutputPathElement != null &&
+                !string.Equals(baseIntermediateOutputPathElement.Value, relativeObjPackagesDirectoryPath.TrimEnd('\\'), StringComparison.Ordinal))
+            {
+                baseIntermediateOutputPathElement.Value = relativeObjPackagesDirectoryPath.TrimEnd('\\');
+                hasChanged = true;
+            }
+
+            var outputPathElement = buildProject
+                .Xml
+                .PropertyGroups
+                .FirstOrDefault(x => string.Equals(x.Label, "Globals"))?
+                .Children
+                .OfType<ProjectPropertyElement>()
+                .FirstOrDefault(x => string.Equals(x.Name, OutputPathPropertyName));
+            if (outputPathElement != null &&
+                !string.Equals(outputPathElement.Value, relativeBinPackagesDirectoryPath, StringComparison.Ordinal))
+            {
+                outputPathElement.Value = relativeBinPackagesDirectoryPath;
+                hasChanged = true;
+            }
+
+            if (hasChanged)
+            {
+                buildProject.Save();
+                ProjectHelper.ReloadProject(project);
             }
         }
 
@@ -46,73 +107,6 @@
         public bool ShouldAddProjectItem(string filePath)
         {
             return true;
-        }
-
-        #endregion
-
-        #region Private Static Methods
-
-        private static bool Execute(string solutionFilePath, string projectFilePath)
-        {
-            bool hasChanged = false;
-
-            if (!string.Equals(Path.GetExtension(projectFilePath), ".xproj"))
-            {
-                return hasChanged;
-            }
-
-            var projectDirectoryPath = Path.GetDirectoryName(projectFilePath);
-            var solutionDirectoryPath = string.IsNullOrEmpty(solutionFilePath) ? projectDirectoryPath : Path.GetDirectoryName(solutionFilePath);
-
-            var artifactsObjDirectoryPath = Path.Combine(solutionDirectoryPath, @"artifacts\obj\$(MSBuildProjectName)");
-            var artifactsBinDirectoryPath = Path.Combine(solutionDirectoryPath, @"artifacts\bin\$(MSBuildProjectName)");
-
-            var relativeObjPackagesDirectoryPath = PathHelper.GetRelativePath(
-                projectDirectoryPath,
-                artifactsObjDirectoryPath)
-                .TrimEnd('\\');
-            var relativeBinPackagesDirectoryPath = PathHelper.GetRelativePath(
-                projectDirectoryPath,
-                artifactsBinDirectoryPath);
-
-            //<PropertyGroup Label="Globals">
-            //  <ProjectGuid>6e0ef33d-3c19-4ea2-8ca9-c7bf19bdd947</ProjectGuid>
-            //  <RootNamespace>MvcBoilerplate</RootNamespace>
-            //  <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-            //  <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
-            //</PropertyGroup>
-
-            Project buildProject = new Project(projectFilePath);
-
-            var baseIntermediateOutputPathElement = buildProject
-                .Xml
-                .PropertyGroups
-                .FirstOrDefault(x => string.Equals(x.Label, "Globals"))?
-                .Children
-                .OfType<ProjectPropertyElement>()
-                .FirstOrDefault(x => string.Equals(x.Name, "BaseIntermediateOutputPath"));
-            if (baseIntermediateOutputPathElement != null &&
-                !string.Equals(baseIntermediateOutputPathElement.Value, relativeObjPackagesDirectoryPath, StringComparison.Ordinal))
-            {
-                baseIntermediateOutputPathElement.Value = relativeObjPackagesDirectoryPath;
-                hasChanged = true;
-            }
-
-            var outputPathElement = buildProject
-                .Xml
-                .PropertyGroups
-                .FirstOrDefault(x => string.Equals(x.Label, "Globals"))?
-                .Children
-                .OfType<ProjectPropertyElement>()
-                .FirstOrDefault(x => string.Equals(x.Name, "OutputPath"));
-            if (outputPathElement != null &&
-                !string.Equals(outputPathElement.Value, relativeBinPackagesDirectoryPath, StringComparison.Ordinal))
-            {
-                outputPathElement.Value = relativeBinPackagesDirectoryPath;
-                hasChanged = true;
-            }
-
-            return hasChanged;
         }
 
         #endregion

--- a/src/TemplateBuilder/FixArtifactsPathWizard.cs
+++ b/src/TemplateBuilder/FixArtifactsPathWizard.cs
@@ -1,0 +1,120 @@
+﻿namespace TemplateBuilder
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using Microsoft.Build.Construction;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.VisualStudio.TemplateWizard;
+
+    public class FixArtifactsPathWizard : IWizard
+    {
+        #region Public Methods
+
+        public void BeforeOpeningFile(global::EnvDTE.ProjectItem projectItem)
+        {
+        }
+        
+        public void ProjectFinishedGenerating(global::EnvDTE.Project project)
+        {
+            var projectFilePath = project.FileName;
+            var solutionFilePath = project.DTE.Solution.FileName;
+
+            if (Execute(solutionFilePath, projectFilePath))
+            {
+                project.Save();
+            }
+        }
+
+        public void ProjectItemFinishedGenerating(global::EnvDTE.ProjectItem projectItem)
+        {
+        }
+
+        public void RunFinished()
+        {
+        }
+
+        public void RunStarted(
+            object automationObject,
+            Dictionary<string, string> replacementsDictionary,
+            WizardRunKind runKind,
+            object[] customParams)
+        {
+        }
+
+        public bool ShouldAddProjectItem(string filePath)
+        {
+            return true;
+        }
+
+        #endregion
+
+        #region Private Static Methods
+
+        private static bool Execute(string solutionFilePath, string projectFilePath)
+        {
+            bool hasChanged = false;
+
+            if (!string.Equals(Path.GetExtension(projectFilePath), ".xproj"))
+            {
+                return hasChanged;
+            }
+
+            var projectDirectoryPath = Path.GetDirectoryName(projectFilePath);
+            var solutionDirectoryPath = string.IsNullOrEmpty(solutionFilePath) ? projectDirectoryPath : Path.GetDirectoryName(solutionFilePath);
+
+            var artifactsObjDirectoryPath = Path.Combine(solutionDirectoryPath, @"artifacts\obj\$(MSBuildProjectName)");
+            var artifactsBinDirectoryPath = Path.Combine(solutionDirectoryPath, @"artifacts\bin\$(MSBuildProjectName)");
+
+            var relativeObjPackagesDirectoryPath = PathHelper.GetRelativePath(
+                projectDirectoryPath,
+                artifactsObjDirectoryPath)
+                .TrimEnd('\\');
+            var relativeBinPackagesDirectoryPath = PathHelper.GetRelativePath(
+                projectDirectoryPath,
+                artifactsBinDirectoryPath);
+
+            //<PropertyGroup Label="Globals">
+            //  <ProjectGuid>6e0ef33d-3c19-4ea2-8ca9-c7bf19bdd947</ProjectGuid>
+            //  <RootNamespace>MvcBoilerplate</RootNamespace>
+            //  <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+            //  <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+            //</PropertyGroup>
+
+            Project buildProject = new Project(projectFilePath);
+
+            var baseIntermediateOutputPathElement = buildProject
+                .Xml
+                .PropertyGroups
+                .FirstOrDefault(x => string.Equals(x.Label, "Globals"))?
+                .Children
+                .OfType<ProjectPropertyElement>()
+                .FirstOrDefault(x => string.Equals(x.Name, "BaseIntermediateOutputPath"));
+            if (baseIntermediateOutputPathElement != null &&
+                !string.Equals(baseIntermediateOutputPathElement.Value, relativeObjPackagesDirectoryPath, StringComparison.Ordinal))
+            {
+                baseIntermediateOutputPathElement.Value = relativeObjPackagesDirectoryPath;
+                hasChanged = true;
+            }
+
+            var outputPathElement = buildProject
+                .Xml
+                .PropertyGroups
+                .FirstOrDefault(x => string.Equals(x.Label, "Globals"))?
+                .Children
+                .OfType<ProjectPropertyElement>()
+                .FirstOrDefault(x => string.Equals(x.Name, "OutputPath"));
+            if (outputPathElement != null &&
+                !string.Equals(outputPathElement.Value, relativeBinPackagesDirectoryPath, StringComparison.Ordinal))
+            {
+                outputPathElement.Value = relativeBinPackagesDirectoryPath;
+                hasChanged = true;
+            }
+
+            return hasChanged;
+        }
+
+        #endregion
+    }
+}

--- a/src/TemplateBuilder/FixNuGetPackageHintPathsWizard.cs
+++ b/src/TemplateBuilder/FixNuGetPackageHintPathsWizard.cs
@@ -7,6 +7,7 @@
     using Microsoft.Build.Evaluation;
     using Microsoft.VisualStudio.TemplateWizard;
     using NuGet;
+    using TemplateBuilder.Helpers;
 
     public class FixNuGetPackageHintPathsWizard : IWizard
     {
@@ -104,7 +105,7 @@
                     // So for safety we do nothing.
                 }
             }
-
+            
             return hasChanged;
         }
 

--- a/src/TemplateBuilder/Helpers/PathHelper.cs
+++ b/src/TemplateBuilder/Helpers/PathHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateBuilder
+﻿namespace TemplateBuilder.Helpers
 {
     using System;
     using System.IO;

--- a/src/TemplateBuilder/Helpers/ProjectHelper.cs
+++ b/src/TemplateBuilder/Helpers/ProjectHelper.cs
@@ -1,0 +1,27 @@
+﻿namespace TemplateBuilder.Helpers
+{
+    using System.IO;
+    using Microsoft.VisualStudio.Shell;
+
+    internal static class ProjectHelper
+    {
+        public static void ReloadProject(global::EnvDTE.Project currentProject)
+        {
+            var dte2 = (global::EnvDTE80.DTE2)Package.GetGlobalService(typeof(global::EnvDTE.DTE));
+
+            dte2.ExecuteCommand("File.SaveAll");
+
+            string solutionName = Path.GetFileNameWithoutExtension(dte2.Solution.FullName);
+            string projectName = currentProject.Name;
+
+            dte2.Windows.Item(global::EnvDTE.Constants.vsWindowKindSolutionExplorer).Activate();
+            dte2.ToolWindows.SolutionExplorer
+                .GetItem(solutionName + @"\" + projectName)
+                .Select(global::EnvDTE.vsUISelectionType.vsUISelectionTypeSelect);
+
+            dte2.ExecuteCommand("Project.UnloadProject");
+            System.Threading.Thread.Sleep(500);
+            dte2.ExecuteCommand("Project.ReloadProject");
+        }
+    }
+}

--- a/src/TemplateBuilder/PathHelper.cs
+++ b/src/TemplateBuilder/PathHelper.cs
@@ -1,0 +1,59 @@
+﻿namespace TemplateBuilder
+{
+    using System;
+    using System.IO;
+
+    internal static class PathHelper
+    {
+        /// <summary>
+        /// Creates a relative path from one file or folder to another.
+        /// </summary>
+        /// <param name="fromPath">Contains the directory that defines the start of the relative path.</param>
+        /// <param name="toPath">Contains the path that defines the endpoint of the relative path.</param>
+        /// <returns>The relative path from the start directory to the end path.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="fromPath"/> or <paramref name="toPath"/> is <c>null</c>.</exception>
+        /// <exception cref="UriFormatException"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static string GetRelativePath(string fromPath, string toPath)
+        {
+            if (string.IsNullOrEmpty(fromPath))
+            {
+                throw new ArgumentNullException(nameof(fromPath));
+            }
+
+            if (string.IsNullOrEmpty(toPath))
+            {
+                throw new ArgumentNullException(nameof(toPath));
+            }
+
+            var fromUri = new Uri(AppendDirectorySeparatorChar(fromPath));
+            var toUri = new Uri(AppendDirectorySeparatorChar(toPath));
+
+            if (fromUri.Scheme != toUri.Scheme)
+            {
+                return toPath;
+            }
+
+            var relativeUri = fromUri.MakeRelativeUri(toUri);
+            var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+
+            if (string.Equals(toUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            {
+                relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            }
+
+            return relativePath;
+        }
+
+        private static string AppendDirectorySeparatorChar(string directoryPath)
+        {
+            if (!Path.HasExtension(directoryPath) &&
+                !directoryPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                return directoryPath + Path.DirectorySeparatorChar;
+            }
+
+            return directoryPath;
+        }
+    }
+}

--- a/src/TemplateBuilder/TemplateBuilder.csproj
+++ b/src/TemplateBuilder/TemplateBuilder.csproj
@@ -34,11 +34,6 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-<<<<<<< HEAD
-    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-=======
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -50,10 +45,12 @@
     </Reference>
     <Reference Include="envdte90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
->>>>>>> 4c9c4521f917861527e4c5fe150caccd59376b97
     </Reference>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>

--- a/src/TemplateBuilder/TemplateBuilder.csproj
+++ b/src/TemplateBuilder/TemplateBuilder.csproj
@@ -31,14 +31,18 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60717.93, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Core.2.8.6\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.10.1.766, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -50,12 +54,15 @@
     <Compile Include="ChildWizard.cs" />
     <Compile Include="FixArtifactsPathWizard.cs" />
     <Compile Include="FixNuGetPackageHintPathsWizard.cs" />
-    <Compile Include="PathHelper.cs" />
+    <Compile Include="Helpers\PathHelper.cs" />
+    <Compile Include="Helpers\ProjectHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RootWizard.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/TemplateBuilder/TemplateBuilder.csproj
+++ b/src/TemplateBuilder/TemplateBuilder.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TemplateBuilder</RootNamespace>
     <AssemblyName>TemplateBuilder</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
@@ -47,10 +49,7 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>

--- a/src/TemplateBuilder/TemplateBuilder.csproj
+++ b/src/TemplateBuilder/TemplateBuilder.csproj
@@ -30,9 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -50,7 +48,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChildWizard.cs" />
+    <Compile Include="FixArtifactsPathWizard.cs" />
     <Compile Include="FixNuGetPackageHintPathsWizard.cs" />
+    <Compile Include="PathHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RootWizard.cs" />
   </ItemGroup>

--- a/src/TemplateBuilder/packages.config
+++ b/src/TemplateBuilder/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.6" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
 </packages>

--- a/src/TemplateBuilder/packages.config
+++ b/src/TemplateBuilder/packages.config
@@ -1,10 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-<<<<<<< HEAD
-  <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
-=======
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.6" targetFramework="net45" />
->>>>>>> 4c9c4521f917861527e4c5fe150caccd59376b97
+  <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
See https://github.com/ligershark/side-waffle/issues/326

Appveyor is complaining because I had to add a dependency on Microsoft.Visual Studio.Shell which it can't find. Any ideas on how I can fix this?