### PR TITLE
Update NuGet.Core and add a ReloadProjectWizard

### DIFF
--- a/src/TemplateBuilder/ReloadProjectWizard.cs
+++ b/src/TemplateBuilder/ReloadProjectWizard.cs
@@ -1,0 +1,43 @@
+﻿namespace TemplateBuilder
+{
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TemplateWizard;
+    using TemplateBuilder.Helpers;
+
+    public class ReloadProjectWizard : IWizard
+    {
+        #region Public Methods
+
+        public void BeforeOpeningFile(global::EnvDTE.ProjectItem projectItem)
+        {
+        }
+
+        public void ProjectFinishedGenerating(global::EnvDTE.Project project)
+        {
+            ProjectHelper.ReloadProject(project);
+        }
+
+        public void ProjectItemFinishedGenerating(global::EnvDTE.ProjectItem projectItem)
+        {
+        }
+
+        public void RunFinished()
+        {
+        }
+
+        public void RunStarted(
+            object automationObject,
+            Dictionary<string, string> replacementsDictionary,
+            WizardRunKind runKind,
+            object[] customParams)
+        {
+        }
+
+        public bool ShouldAddProjectItem(string filePath)
+        {
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/src/TemplateBuilder/TemplateBuilder.csproj
+++ b/src/TemplateBuilder/TemplateBuilder.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChildWizard.cs" />
+    <Compile Include="ReloadProjectWizard.cs" />
     <Compile Include="FixArtifactsPathWizard.cs" />
     <Compile Include="FixNuGetPackageHintPathsWizard.cs" />
     <Compile Include="Helpers\PathHelper.cs" />

--- a/src/TemplateBuilder/TemplateBuilder.csproj
+++ b/src/TemplateBuilder/TemplateBuilder.csproj
@@ -55,8 +55,8 @@
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.10.1.766, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core, Version=2.11.1.812, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/TemplateBuilder/packages.config
+++ b/src/TemplateBuilder/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.11.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The `ReloadProjectWizard` can be used to reload a project. This is useful as it forces VS to restore NuGet, NPM and Bower packages in the new xproj projects.

The `FixArtifactsPathWizard` already does this but it also fixes the build output relative file paths. With the RC2 release, we have gone back to using bin and obj folders under a project so this is no longer needed.
